### PR TITLE
Fix for VS2019 error C2039: 'runtime_error': is not a member of 'std'

### DIFF
--- a/src/hacklib/src/Main_WIN32.cpp
+++ b/src/hacklib/src/Main_WIN32.cpp
@@ -1,5 +1,6 @@
 #include "hacklib/Main.h"
 #include <Windows.h>
+#include <stdexcept>
 
 
 static DWORD WINAPI ThreadFunc(LPVOID param)

--- a/src/hacklib/src/PatternScanner.cpp
+++ b/src/hacklib/src/PatternScanner.cpp
@@ -4,6 +4,7 @@
 #include <unordered_map>
 #include <iterator>
 #include <cstring>
+#include <stdexcept>
 
 
 using namespace hl;


### PR DESCRIPTION
I got this error compiling on Visual Studio 2019:

error C2039: 'runtime_error': is not a member of 'std'

The error can be fixed by including <stdexcept> on the files using runtime_error.